### PR TITLE
[Python] Challenge #10 (Pending)

### DIFF
--- a/challenge_10/python/ning/README.md
+++ b/challenge_10/python/ning/README.md
@@ -1,0 +1,25 @@
+# Challenge #10, Valid Closers
+
+I found three cases where the sequence can be considered to have 'invalid closers'.
+
+1. A mismatch in the number of opening and closing brackets, e.g. `())`
+2. Premature closing, e.g. `][`
+3. Overlapping of brackets, e.g. `([<)]>`
+
+In this solution, we use a list to 'count' the brackets as we iterate through the list. Every opening bracket adds to this list `mem`, and closing brackets remove their corresponding openings from the list.
+
+The first invalid case is partially tested for by checking if the list `mem` is empty at the end of the iteration. The works for an abundance, but not shortage of opening brackets.
+
+For the case whereby there is a shortage of closing brackets, we simply return False in the case of an `IndexError`. This also covers the second case of premature closing.
+
+For the third case of overlapping, we check for every closing bracket if the most recent _unclosed_ opening bracket is of the same type. If not, False is returned as expected.
+
+The unit test, `test.py`, is constructed simply from the examples given.
+
+```
+.........
+----------------------------------------------------------------------
+Ran 9 tests in 0.001s
+
+OK
+```

--- a/challenge_10/python/ning/challenge_10.py
+++ b/challenge_10/python/ning/challenge_10.py
@@ -1,0 +1,39 @@
+def check_close(input_string):
+    OPENS  = ('(', '<', '[', '{')
+    CLOSES = (')', '>', ']', '}')
+    PAREN  = ('(', ')')
+    ANGLE  = ('<', '>')
+    SQUARE = ('[', ']')
+    CURLY  = ('{', '}')
+    mem = []
+
+    for character in input_string:
+        try:
+            if character in OPENS:
+                mem.append(character)
+            elif character in CLOSES:
+                if   (character in PAREN and
+                      mem[-1] in PAREN):
+                      del mem[-1]
+                elif (character in ANGLE and
+                      mem[-1] in ANGLE):
+                      del mem[-1]
+                elif (character in SQUARE and
+                      mem[-1] in SQUARE):
+                      del mem[-1]
+                elif (character in CURLY and
+                      mem[-1] in CURLY):
+                      del mem[-1]
+                else:
+                    return False
+        except IndexError:
+            return False
+
+    if mem == []:
+        return True
+    else:
+        return False
+
+if __name__ == '__main__':
+    while True:
+        print(check_close(input(' >>> ')))

--- a/challenge_10/python/ning/test.py
+++ b/challenge_10/python/ning/test.py
@@ -1,0 +1,60 @@
+import unittest
+from challenge_10 import check_close
+
+class Tests(unittest.TestCase):
+    def test_1(self):
+        self.assertEqual(
+                check_close('{{{{{{{{{adfkjaefia}}}}}}}'),
+                False
+                )
+
+    def test_2(self):
+        self.assertEqual(
+                check_close('{{{{{{{{{[[[[[[kadfa{{{{{{{((({daljfdaf({{{[]}}kaldjfs})})))}}}}}}}]]]]]]}kjfela}}}}}}}}'),
+                True
+                )
+
+    def test_3(self):
+        self.assertEqual(
+                check_close('{{{[}}}}dafda'),
+                False
+                )
+
+    def test_4(self):
+        self.assertEqual(
+                check_close('{{{{{{{{{}}}}}}}}}'),
+                True
+                )
+
+    def test_5(self):
+        self.assertEqual(
+                check_close('[[[[[[[[[kafjalfeianfailfeja;fjai;efa;sfj]]]]]]]]]kjajdain'),
+                True
+                )
+
+    def test_6(self):
+        self.assertEqual(
+                check_close('< blank >'),
+                True
+                )
+
+    def test_7(self):
+        self.assertEqual(
+                check_close('((((((fjdalfeja((((alefjalisj(())))))))))))d'),
+                True
+                )
+
+    def test_8(self):
+        self.assertEqual(
+                check_close(')))(((d'),
+                False
+                )
+    
+    def test_9(self):
+        self.assertEqual(
+                check_close('({)}'),
+                False
+                )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
I found three cases where the sequence can be considered to have 'invalid closers'.

1. A mismatch in the number of opening and closing brackets, e.g. `())`
2. Premature closing, e.g. `][`
3. Overlapping of brackets, e.g. `([<)]>`

In this solution, we use a list to 'count' the brackets as we iterate through the list. Every opening bracket adds to this list `mem`, and closing brackets remove their corresponding openings from the list.

The first invalid case is partially tested for by checking if the list `mem` is empty at the end of the iteration. The works for an abundance, but not shortage of opening brackets.

For the case whereby there is a shortage of closing brackets, we simply return False in the case of an `IndexError`. This also covers the second case of premature closing.

For the third case of overlapping, we check for every closing bracket if the most recent _unclosed_ opening bracket is of the same type. If not, False is returned as expected.

The unit test, `test.py`, is constructed simply from the examples given.

```
.........
----------------------------------------------------------------------
Ran 9 tests in 0.001s

OK
```